### PR TITLE
Update migrationfile

### DIFF
--- a/db/migrate/20200711124940_change_column_to_article.rb
+++ b/db/migrate/20200711124940_change_column_to_article.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToArticle < ActiveRecord::Migration[5.2]
+  def up
+    change_column :articles, :article_content, :text, null: false, limit: 4294967295
+  end
+
+  def down
+    change_column :articles, :article_content, :text, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_090614) do
+ActiveRecord::Schema.define(version: 2020_07_11_124940) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2020_06_24_090614) do
   create_table "articles", force: :cascade do |t|
     t.integer "admin_id", null: false
     t.string "article_title", null: false
-    t.text "article_content", null: false
+    t.text "article_content", limit: 4294967295, null: false
     t.string "article_image_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
**Update**

- 本番環境にて画像を保存しようとするとActiveRecord::ValueTooLong (Mysql2::Error: Data too longとエラーが出たため、article_contentにlimitをつけてLONGTEXT型に変更しました。