### PR TITLE
ゲストログイン機能の追加

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
+  before_action :check_guest, only: :create
+
+  def check_guest
+    if params[:user][:email].downcase == 'guest@example.com'
+      redirect_to root_path, alert: 'ゲストユーザーの情報の変更・削除はできません'
+    end
+  end
+
   # GET /resource/password/new
   # def new
   #   super

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,6 +3,13 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
+  before_action :check_guest, only: :destroy
+
+  def check_guest
+    if resource.email == 'guest@example.com'
+      redirect_to root_path, alert: 'ゲストユーザーは削除できません'
+    end
+  end
 
   # GET /resource/sign_up
   # def new

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,11 +3,11 @@
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
-  before_action :check_guest, only: :destroy
+  before_action :check_guest, only: [:update, :destroy]
 
   def check_guest
     if resource.email == 'guest@example.com'
-      redirect_to root_path, alert: 'ゲストユーザーは削除できません'
+      redirect_to root_path, alert: 'ゲストユーザー情報の変更・削除はできません'
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -24,4 +24,10 @@ class Users::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+
+  def new_guest
+    user = User.guest
+    sign_in user
+    redirect_to post_images_path, notice: 'ゲストユーザーとしてログインしました'
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
   before_action :user_restrict, only:[:edit, :destroy]
+  before_action :check_guest, only: [:update]
 
   def index
     @users = User.all.page(params[:page]).per(15)
@@ -49,6 +50,13 @@ class UsersController < ApplicationController
     user = User.find(params[:id])
     if user != current_user
       redirect_to post_images_path, notice: "⚠️他人の会員情報は編集できません"
+    end
+  end
+
+  def check_guest
+    @user = User.find(params[:id])
+    if @user.email == 'guest@example.com' && @user.name == 'ゲストユーザー'
+      redirect_to user_path(@user.id), notice: 'ゲストユーザーの情報は変更できません'
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,12 @@ class User < ApplicationRecord
   def following?(other_user)
     following.include?(other_user)
   end
+
+  # ゲストユーザーを探す、ゲストユーザーを作成する
+  def self.guest
+    # find_or create_by = 引数の条件に該当するデータがあればそれを返す(find_by)なければ作成(create)
+    find_or_create_by!(name: 'ゲストユーザー', email: 'guest@example.com') do |user|
+      user.password = SecureRandom.urlsafe_base64 # SecureRandom = 乱数生成、urlsafe_base64 = ランダムでURL-safeなbase64文字列を生成して返す
+    end
+  end
 end

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -37,6 +37,7 @@
 
   <% end %>
 
-  <%= render "users/shared/links" %>
-  <%= link_to '管理者の方はこちら' ,new_admin_session_path %>
+  <%= render "users/shared/links" %><br>
+  <%= link_to 'ゲストログイン(閲覧用)', users_guest_sign_in_path, method: :post %><br>
+  <%= link_to '管理者の方はこちら', new_admin_session_path %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,10 @@ Rails.application.routes.draw do
     registrations: 'users/registrations'
   }
 
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#new_guest'
+  end
+
   # ユーザー関係
   root 'homes#top'
   get '/about' => 'homes#about'


### PR DESCRIPTION
閲覧のみのユーザーのためゲストログイン機能を追加しました。

・ゲスト情報をあるか検索しあればログイン、なければ作成(find_or_create_by)
・サインインページにゲストログイン用ボタンを設置
・ゲストの会員情報編集ページの制限（編集不可のため詳細ページへリダイレクト&アラート表示）
・ゲストのパスワード編集を禁止